### PR TITLE
Add support for PHP 8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All Notable changes to the **Quality Assurance - PHP** package.
 
+## [1.1.0]
+
+### Added
+
+- Add support for PHP 8.x
+
+### Changed
+
+- Change minimal PHP version to 7.4.x
+
+### Updated
+
+- Update minimal package versions.
+
 ## [1.0.0]
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true,
+            "phpro/grumphp-shim": true
+        }
     },
     "autoload": {
         "psr-4": {
@@ -37,18 +41,18 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": "^7.4|^8.0",
         "ergebnis/composer-normalize": "^2.8",
-        "irstea/phpcpd-shim": "^6.0",
-        "irstea/phpmd-shim": "^2.9",
         "nette/neon": "^3.2",
+        "phpmd/phpmd": "^2.11",
         "phpro/grumphp-shim": "^1.1",
         "phpspec/prophecy": "^1.10",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpstan/phpstan": "^0.12.6",
-        "phpstan/phpstan-deprecation-rules": "^0.12.5",
+        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9",
         "squizlabs/php_codesniffer": "^3.5.6",
+        "sebastian/phpcpd": "^6.0",
         "symfony/filesystem": "^5.2"
     }
 }


### PR DESCRIPTION
Add support for PHP 8.

## Description

Add support to use this package within PHP 8.x projects.

- Change minimal PHP version to 7.4.+
- Add support for PHP 8.x
- Update minimal package versions.

## Motivation and Context

PHP 7.x is EOL end 2022, prepare our packages for PHP 8.x.

## Types of changes

- [x] New feature (non-breaking change which adds functionality).

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [x] I have read the **CONTRIBUTING** document.
