### PR TITLE
Upgrade minimal php version to 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 php:
-  - 7.3
-  - 7.4
-  - 8.0
   - 8.1
+  - 8.2
+  - 8.3
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: jammy
+
 language: php
 php:
   - 8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All Notable changes to the **Quality Assurance - PHP** package.
 ### Updated
 
 - Update GrumPHP to 2.x.
+- Update security-checker package to 2.x.
 
 ## [1.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All Notable changes to the **Quality Assurance - PHP** package.
 
+## [Unreleased]
+
+### Added
+
+- Add support for .dist files in the project.
+
+### Changed
+
+- Changed minimal PHP version to 8.1.
+
+### Fixed
+
+- Fix merging configs when both have same string keys.
+
+### Updated
+
+- Update GrumPHP to 2.x.
+
 ## [1.1.0]
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "require": {
         "php": "^8.1",
-        "enlightn/security-checker": "^1.4",
+        "enlightn/security-checker": "^1.4|^2.0",
         "ergebnis/composer-normalize": "^2.8",
         "nette/neon": "^3.2",
         "phpcompatibility/php-compatibility": "^9.3",

--- a/composer.json
+++ b/composer.json
@@ -41,20 +41,20 @@
         }
     },
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.1",
         "enlightn/security-checker": "^1.4",
         "ergebnis/composer-normalize": "^2.8",
         "nette/neon": "^3.2",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpmd/phpmd": "^2.11",
-        "phpro/grumphp-shim": "^1.1",
+        "phpro/grumphp-shim": "^2.0",
         "phpspec/prophecy": "^1.10",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9",
-        "squizlabs/php_codesniffer": "^3.5.6",
         "sebastian/phpcpd": "^6.0",
-        "symfony/filesystem": "^5.2"
+        "squizlabs/php_codesniffer": "^3.5.6",
+        "symfony/filesystem": "^5.2|^6.0|^7.0"
     }
 }

--- a/src/GrumPHP/EventListener/TaskEventListener.php
+++ b/src/GrumPHP/EventListener/TaskEventListener.php
@@ -123,7 +123,8 @@ final class TaskEventListener
             if ($dataMerged === null) {
                 $dataMerged = $data;
             } elseif ($data) {
-                $dataMerged = array_merge_recursive($data, $dataMerged);
+                $beforeMerged = $dataMerged;
+                $dataMerged = $this->arrayMergeRecursiveDistinct($data, $dataMerged);
             }
         }
 
@@ -210,5 +211,37 @@ final class TaskEventListener
 
         $filesystem = new Filesystem();
         $filesystem->dumpFile($file, $rawData);
+    }
+
+    /**
+     * Merge array recursive but keep distinct string keys.
+     *
+     * array_merge_recursive does indeed merge arrays, but it converts values
+     * with duplicate keys to arrays rather than overwriting the value in the
+     * first array with the duplicate value in the second array, as array_merge
+     * does.
+     *
+     * @param array $array1
+     *   The array to merge data with.
+     * @param array $array2
+     *   The array to merge data from.
+     *
+     * @return array
+     *   The merged arrays.
+     *
+     * @see https://www.php.net/manual/en/function.array-merge-recursive.php#92195
+     */
+    private function arrayMergeRecursiveDistinct(array $array1, array $array2): array
+    {
+        foreach ($array2 as $key => $value ) {
+            if (is_array($value) && isset($array1[$key]) && is_array($array1[$key])) {
+                $array1[$key] = $this->arrayMergeRecursiveDistinct($array1[$key], $value);
+                continue;
+            }
+
+            $array1[$key] = $value;
+        }
+
+        return $array1;
     }
 }

--- a/src/GrumPHP/EventListener/TaskEventListener.php
+++ b/src/GrumPHP/EventListener/TaskEventListener.php
@@ -82,6 +82,16 @@ final class TaskEventListener
                 $info['filename'],
                 $info['extension']
             ),
+            $keyPrefix . 'EXT_DIST' => sprintf(
+                '%s.%s.dist',
+                $info['filename'],
+                $info['extension']
+            ),
+            $keyPrefix . 'DIST_EXT' => sprintf(
+                '%s.dist.%s',
+                $info['filename'],
+                $info['extension']
+            ),
             $keyPrefix . 'GLOBAL' => sprintf(
                 '%s%s.%s',
                 $packagePath,


### PR DESCRIPTION
## Description

- Upgrade the package to support minimal PHP 8.1.
- Add support for .dist files.
- Fix broken configs when merging config arrays with array_merge_recursive().
- Update GrumPHP to 2.x.
- Update security-checker package to 2.x.

## Motivation and Context

Older PHP versions are end of life.

## How Has This Been Tested?

Tested setup in a fresh Symfony project.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Documentation update.
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [x] I have read the **CONTRIBUTING** document.
