### PR TITLE
Add Unused use statement rule to PHPCS checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to the **Quality Assurance - PHP** package.
 
+## [Unreleased]
+
+### Added
+
+- Add Unused use statement rule to PHPCS checks.
+
 ## [2.0.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the `grumphp` entry to the `extra` section of your `composer.json`.
 Add the qa-php package as dev requirement:
 
 ```bash
-composer require --dev district09/qa-php:^1.0
+composer require --dev district09/qa-php:^2.0
 ```
 
 ## Configuration

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "ergebnis/composer-normalize": true,
-            "phpro/grumphp-shim": true
+            "phpro/grumphp-shim": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "autoload": {
@@ -54,6 +55,7 @@
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9",
         "sebastian/phpcpd": "^6.0",
+        "slevomat/coding-standard": "^8.15",
         "squizlabs/php_codesniffer": "^3.5.6",
         "symfony/filesystem": "^5.2|^6.0|^7.0"
     }

--- a/configs/phpcs.xml
+++ b/configs/phpcs.xml
@@ -13,4 +13,7 @@
     <arg value="np"/>
 
     <rule ref="PSR12"></rule>
+
+    <!-- Extra rules not included in PSR12. -->
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
 </ruleset>


### PR DESCRIPTION
Add extra rule to avoid unused use statements in PHP files.

## Description

IDE's add the use-statements automatically when you write code, they don't remove them when they are no longer required.

## Motivation and Context

Avoid unused code.

## How Has This Been Tested?

Tested within a project.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Documentation update.
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [x] I have read the **CONTRIBUTING** document.
