### PR TITLE
Add 'Revert' as a valid begin of a commit message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All Notable changes to the **Quality Assurance - PHP** package.
 ### Added
 
 - Add Unused use statement rule to PHPCS checks.
+- 'Revert' is now a valid start of a commit message.
 
 ## [2.0.0]
 

--- a/configs/grumphp.yml
+++ b/configs/grumphp.yml
@@ -51,7 +51,7 @@ grumphp:
                 - "#^main|^master|^develop|^\\d+(\\.\\d+)?\\.x|^(release|hotfix)/\\d+\\.\\d+\\.\\d+|^feature/([A-Z][A-Z\\d]+-\\d+|[a-z][a-z\\d]*(-[a-z\\d]+)*)$#"
         git_commit_message:
             matchers:
-                - "/^([A-Z][A-Z\\d]+-\\d+(, [A-Z][A-Z\\d]+-\\d+)*: )?(Add|Change|Fix|Update|Remove|Refactor|Merge|RELEASE) /"
+                - "/^([A-Z][A-Z\\d]+-\\d+(, [A-Z][A-Z\\d]+-\\d+)*: )?(Add|Change|Fix|Update|Remove|Refactor|Revert|Merge|RELEASE) /"
             case_insensitive: false
         phpcpd:
             exclude:


### PR DESCRIPTION
When you revert a commit, Git prepares a decent commit message starting with "Revert", this change allows such commits.

Closes #8

- [X] I have updated the CHANGELOG accordingly.
